### PR TITLE
docs: add more docstrings

### DIFF
--- a/src/renderer/bridge.rs
+++ b/src/renderer/bridge.rs
@@ -9,8 +9,11 @@ pub mod ffi {
     #[repr(u32)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum MapMode {
+        /// continually updating map
         Continuous,
+        /// once-off still image of an arbitrary viewport
         Static,
+        /// once-off still image of a single tile
         Tile,
     }
 
@@ -18,10 +21,14 @@ pub mod ffi {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum MapDebugOptions {
         NoDebug = 0,
+        /// Edges of tile boundaries are shown as thick, red lines to help diagnose tile clipping issues.
         TileBorders = 0b0000_0010, // 1 << 1
         ParseStatus = 0b0000_0100, // 1 << 2
+        /// Each tile shows a timestamp indicating when it was loaded.
         Timestamps = 0b0000_1000,  // 1 << 3
+        /// Edges of glyphs and symbols are shown as faint, green lines to help diagnose collision and label placement issues.
         Collision = 0b0001_0000,   // 1 << 4
+        /// Each drawing operation is replaced by a translucent fill. Overlapping drawing operations appear more prominent to help diagnose overdrawing.
         Overdraw = 0b0010_0000,    // 1 << 5
         StencilClip = 0b0100_0000, // 1 << 6
         DepthBuffer = 0b1000_0000, // 1 << 7

--- a/src/renderer/bridge.rs
+++ b/src/renderer/bridge.rs
@@ -13,7 +13,7 @@ pub mod ffi {
         Continuous,
         /// Once-off still image of an arbitrary viewport
         Static,
-        /// once-off still image of a single tile
+        /// Once-off still image of a single tile
         Tile,
     }
 
@@ -21,14 +21,17 @@ pub mod ffi {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum MapDebugOptions {
         NoDebug = 0,
-        /// Edges of tile boundaries are shown as thick, red lines to help diagnose tile clipping issues.
+        /// Edges of tile boundaries are shown as thick, red lines.
+        /// Can help diagnose tile clipping issues.
         TileBorders = 0b0000_0010, // 1 << 1
         ParseStatus = 0b0000_0100, // 1 << 2
         /// Each tile shows a timestamp indicating when it was loaded.
         Timestamps = 0b0000_1000, // 1 << 3
-        /// Edges of glyphs and symbols are shown as faint, green lines to help diagnose collision and label placement issues.
+        /// Edges of glyphs and symbols are shown as faint, green lines.
+        /// Can help diagnose collision and label placement issues.
         Collision = 0b0001_0000, // 1 << 4
-        /// Each drawing operation is replaced by a translucent fill. Overlapping drawing operations appear more prominent to help diagnose overdrawing.
+        /// Each drawing operation is replaced by a translucent fill.
+        /// Overlapping drawing operations appear more prominent to help diagnose overdrawing.
         Overdraw = 0b0010_0000, // 1 << 5
         StencilClip = 0b0100_0000, // 1 << 6
         DepthBuffer = 0b1000_0000, // 1 << 7

--- a/src/renderer/bridge.rs
+++ b/src/renderer/bridge.rs
@@ -9,9 +9,9 @@ pub mod ffi {
     #[repr(u32)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum MapMode {
-        /// continually updating map
+        /// Continually updating map
         Continuous,
-        /// once-off still image of an arbitrary viewport
+        /// Once-off still image of an arbitrary viewport
         Static,
         /// once-off still image of a single tile
         Tile,

--- a/src/renderer/bridge.rs
+++ b/src/renderer/bridge.rs
@@ -25,11 +25,11 @@ pub mod ffi {
         TileBorders = 0b0000_0010, // 1 << 1
         ParseStatus = 0b0000_0100, // 1 << 2
         /// Each tile shows a timestamp indicating when it was loaded.
-        Timestamps = 0b0000_1000,  // 1 << 3
+        Timestamps = 0b0000_1000, // 1 << 3
         /// Edges of glyphs and symbols are shown as faint, green lines to help diagnose collision and label placement issues.
-        Collision = 0b0001_0000,   // 1 << 4
+        Collision = 0b0001_0000, // 1 << 4
         /// Each drawing operation is replaced by a translucent fill. Overlapping drawing operations appear more prominent to help diagnose overdrawing.
-        Overdraw = 0b0010_0000,    // 1 << 5
+        Overdraw = 0b0010_0000, // 1 << 5
         StencilClip = 0b0100_0000, // 1 << 6
         DepthBuffer = 0b1000_0000, // 1 << 7
     }


### PR DESCRIPTION
during https://github.com/nyurik/maplibre-native-rs/pull/11 I noticed that here we could add a few docstrings.
Not nessesary, but maybe they help somebody down the line.

There are a few values in the enum where I have no clue what they do and they are also not documented => I have ommitted docstrings for them